### PR TITLE
Add retrieval of focal length from camera and publishing it

### DIFF
--- a/library/include/kinectWrapper/kinectDriver.h
+++ b/library/include/kinectWrapper/kinectDriver.h
@@ -114,6 +114,13 @@ public:
     virtual bool get3DPoint(int u, int v, yarp::sig::Vector &point3D) = 0;
 
     /**
+    * Get focal length of attached camera
+    * @param focallength, the focal length of the camera.
+    * @return true/false if successful/failed.
+    */
+    virtual bool getFocalLength(double &focallength) = 0;
+
+    /**
     * Update all the required information.
     */
     virtual void update() = 0;

--- a/library/include/kinectWrapper/kinectDriverOpenNI.h
+++ b/library/include/kinectWrapper/kinectDriverOpenNI.h
@@ -69,6 +69,7 @@ public:
     bool readRgb(yarp::sig::ImageOf<yarp::sig::PixelRgb> &rgb, double &timestamp);
     bool readSkeleton(yarp::os::Bottle *skeleton, double &timestamp);
     bool get3DPoint(int u, int v, yarp::sig::Vector &point3D);
+    bool getFocalLength(double &focallength);
     bool close();
     void update();
     bool getRequireCalibrationPose();

--- a/library/include/kinectWrapper/kinectDriverSDK.h
+++ b/library/include/kinectWrapper/kinectDriverSDK.h
@@ -62,6 +62,7 @@ public:
     bool readDepth(yarp::sig::ImageOf<yarp::sig::PixelMono16> &depth, double &timestamp);
     bool readSkeleton(yarp::os::Bottle *skeleton, double &timestamp);
     bool get3DPoint(int u, int v, yarp::sig::Vector &point3D);
+    bool getFocalLength(double &focallength);
     bool close();
     void update();
 };

--- a/library/include/kinectWrapper/kinectTags.h
+++ b/library/include/kinectWrapper/kinectTags.h
@@ -35,6 +35,7 @@
 #define KINECT_TAGS_CMD_ACK                 "ack"
 #define KINECT_TAGS_CMD_NACK                "nack"
 #define KINECT_TAGS_CMD_GET3DPOINT          "get3D"
+#define KINECT_TAGS_CMD_GETFOCALLENGTH      "getFL"
 #define KINECT_TAGS_SEATED_MODE             "seated"
 #define KINECT_TAGS_CLOSEST_PLAYER          -1
 

--- a/library/include/kinectWrapper/kinectWrapper_client.h
+++ b/library/include/kinectWrapper/kinectWrapper_client.h
@@ -93,6 +93,7 @@ public:
     void getDepthImage(const yarp::sig::ImageOf<yarp::sig::PixelMono16> &depth, yarp::sig::ImageOf<yarp::sig::PixelFloat> &depthToDisplay);
     bool getInfo(yarp::os::Property &opt);
     bool get3DPoint(int u, int v, yarp::sig::Vector &point3D);
+	bool getFocalLength(double &focallength);
     virtual ~KinectWrapperClient();
 };
 

--- a/library/include/kinectWrapper/kinectWrapper_server.h
+++ b/library/include/kinectWrapper/kinectWrapper_server.h
@@ -115,6 +115,7 @@ public:
     void getDepthImage(const yarp::sig::ImageOf<yarp::sig::PixelMono16> &depth, yarp::sig::ImageOf<yarp::sig::PixelFloat> &depthToDisplay);
     bool getInfo(yarp::os::Property &opt);
     bool get3DPoint(int u, int v, yarp::sig::Vector &point3D);
+    bool getFocalLength(double &focallength);
     virtual ~KinectWrapperServer();
 };
 }

--- a/library/src/kinectDriverOpenNI.cpp
+++ b/library/src/kinectDriverOpenNI.cpp
@@ -509,4 +509,20 @@ void KinectDriverOpenNI::resizeImage(IplImage* depthTmp, IplImage* depthImage)
     }
 }
 
+bool KinectDriverOpenNI::getFocalLength(double &focallength)
+{
+    XnUInt64 zeroPlanDistance;
+    XnDouble pixelSize = 1.0;
+    if( depthGenerator.GetIntProperty( "ZPD", zeroPlanDistance ) != XN_STATUS_OK )
+        return false;
+    if( depthGenerator.GetRealProperty( "ZPPS", pixelSize ) != XN_STATUS_OK )
+        return false;
+
+    // pixel size @ VGA = pixel size @ SXGA x 2
+    pixelSize *= 4.0; // in mm
+
+    focallength = (double)zeroPlanDistance / (double)pixelSize;
+
+    return true;
+}
 

--- a/library/src/kinectDriverSDK.cpp
+++ b/library/src/kinectDriverSDK.cpp
@@ -438,6 +438,9 @@ void KinectDriverSDK::update()
     //sdk updates one data stream per time
 }
 
+bool KinectDriverSDK::getFocalLength(double &focallength)
+{
+    focallength = NUI_CAMERA_DEPTH_NOMINAL_FOCAL_LENGTH_IN_PIXELS;
 
-
-
+    return true;
+}

--- a/library/src/kinectWrapper_client.cpp
+++ b/library/src/kinectWrapper_client.cpp
@@ -869,6 +869,36 @@ bool KinectWrapperClient::get3DPoint(int u, int v, yarp::sig::Vector &point3D)
 }
 
 /************************************************************************/
+bool KinectWrapperClient::getFocalLength(double &focallength)
+{
+    if (opening)
+    {
+        Bottle cmd,reply;
+        cmd.addString(KINECT_TAGS_CMD_GETFOCALLENGTH);
+
+        if (rpc.write(cmd,reply))
+        {
+            if (reply.size()>0)
+            {
+                if (reply.get(0).asString()==KINECT_TAGS_CMD_ACK)
+                {
+                    printMessage(1,"successfully connected with the server %s!\n",remote.c_str());
+
+                    focallength=reply.get(1).asDouble();
+
+                    return true;
+                }
+            }
+        }
+        printMessage(1,"unable to get correct reply from the server %s!\n",remote.c_str());
+
+        return false;
+    }
+    else
+        return false;
+}
+
+/************************************************************************/
 bool KinectWrapperClient::isOpen()
 {
     return opening;

--- a/library/src/kinectWrapper_server.cpp
+++ b/library/src/kinectWrapper_server.cpp
@@ -76,6 +76,15 @@ bool KinectWrapperServer::read(ConnectionReader &connection)
             else
                 reply.addString(KINECT_TAGS_CMD_NACK);
         }
+        else if (cmd.get(0).asString()==KINECT_TAGS_CMD_GETFOCALLENGTH) {
+            double focal_length;
+            if(getFocalLength(focal_length)) {
+                reply.addString(KINECT_TAGS_CMD_ACK);
+                reply.addDouble(focal_length);
+            }
+            else
+                reply.addString(KINECT_TAGS_CMD_NACK);
+            }
     }
 
     ConnectionWriter *returnToSender=connection.getWriter();
@@ -828,6 +837,12 @@ void KinectWrapperServer::getDepthImage(const yarp::sig::ImageOf<yarp::sig::Pixe
 bool KinectWrapperServer::get3DPoint(int u, int v, yarp::sig::Vector &point3D)
 {
     driver->get3DPoint(u,v,point3D);
+    return true;
+}
+
+bool KinectWrapperServer::getFocalLength(double &focallength)
+{
+    driver->getFocalLength(focallength);
     return true;
 }
 


### PR DESCRIPTION
So far the kinect server did not provide access to the focal length of the camera. However, this is needed in some libraries. Therefore this PR adds the possibility to retrieve the focal length from the camera (both, using KinectSDK and OpenNI) and publish it such that users have access using the KinectClient.

Let me know if there are any concerns. I tested this in Linux as well as Windows and it works fine.

Best,
Tobias
