### PR TITLE
Allow setting RGB image size for OpenNI driver + Fix kinectClientExample

### DIFF
--- a/library/src/kinectDriverOpenNI.cpp
+++ b/library/src/kinectDriverOpenNI.cpp
@@ -110,7 +110,7 @@ bool KinectDriverOpenNI::initialize(Property &opt)
 
     depthTmp=cvCreateImage(cvSize(def_depth_width,def_depth_height),IPL_DEPTH_16U,1);
     depthImage=cvCreateImage(cvSize(KINECT_TAGS_DEPTH_WIDTH,KINECT_TAGS_DEPTH_HEIGHT),IPL_DEPTH_16U,1);
-    rgb_big=cvCreateImageHeader(cvSize(def_image_width,def_image_height),IPL_DEPTH_8U,3);
+    rgb_big=cvCreateImageHeader(cvSize(img_width,img_height),IPL_DEPTH_8U,3);
     depthMat = cvCreateMat(def_depth_height,def_depth_width,CV_16UC1);
 
     XnStatus nRetVal = XN_STATUS_OK;
@@ -136,6 +136,14 @@ bool KinectDriverOpenNI::initialize(Property &opt)
     {
         nRetVal = imageGenerator.Create(context);
         if (!testRetVal(nRetVal, "Image generator"))
+            return false;
+
+        XnMapOutputMode mapModeImage;
+        mapModeImage.nXRes = this->img_width;
+        mapModeImage.nYRes = this->img_height;
+        mapModeImage.nFPS = 30;
+        nRetVal = imageGenerator.SetMapOutputMode(mapModeImage);
+        if(!testRetVal(nRetVal, "Image Output Setting"))
             return false;
 
         if (requireRemapping && depthGenerator.IsCapabilitySupported(XN_CAPABILITY_ALTERNATIVE_VIEW_POINT))
@@ -242,7 +250,7 @@ bool KinectDriverOpenNI::readRgb(ImageOf<PixelRgb> &rgb, double &timestamp)
 {
     const XnRGB24Pixel* pImage = imageGenerator.GetRGB24ImageMap();
     XnRGB24Pixel* ucpImage = const_cast<XnRGB24Pixel*> (pImage);
-    cvSetData(rgb_big,ucpImage,this->def_image_width*3);
+    cvSetData(rgb_big,ucpImage,this->img_width*3);
     cvResize(rgb_big,(IplImage*)rgb.getIplImage());
     int ts=(int)imageGenerator.GetTimestamp();
     timestamp=(double)ts/1000.0;

--- a/modules/kinectClientExample/src/main.cpp
+++ b/modules/kinectClientExample/src/main.cpp
@@ -17,8 +17,8 @@
 /**
 \defgroup kinectClientExample kinectClientExample
 
-Example module for the use of \ref kinectClientExample "Kinect 
-Wrapper Client". 
+Example module for the use of \ref kinectClientExample "Kinect
+Wrapper Client".
 
 \section intro_sec Description
 This simple module retrieves and display depth and rgb images, players information and the skeleton
@@ -47,6 +47,7 @@ It requires the \ref kinectServer running.
 Windows, Linux
 
 \author Ilaria Gori
+Modified by Tobias Fischer
 */
 
 #include <yarp/os/Network.h>
@@ -71,12 +72,12 @@ protected:
     ImageOf<PixelBgr> skeletonImage;
     IplImage* depthTmp;
     IplImage* rgbTmp;
-    
+
     yarp::os::BufferedPort<yarp::sig::ImageOf<yarp::sig::PixelFloat> > depthPort;
     yarp::os::BufferedPort<yarp::sig::ImageOf<yarp::sig::PixelRgb> > imagePort;
     yarp::os::BufferedPort<yarp::sig::ImageOf<yarp::sig::PixelBgr> > playersPort;
     yarp::os::BufferedPort<yarp::sig::ImageOf<yarp::sig::PixelBgr> > skeletonPort;
-    
+
     bool showImages;
     Player joint;
     deque<Player> joints;
@@ -92,15 +93,15 @@ public:
         string remote=rf.check("remote",Value("kinectServer")).asString().c_str();
         string carrier=rf.check("carrier",Value("udp")).asString().c_str();
         showImages=(show=="true");
-        
+
         depthPort.open("/"+name+"/depthPort:o");
         imagePort.open("/"+name+"/imagePort:o");
         playersPort.open("/"+name+"/playersPort:o");
         skeletonPort.open("/"+name+"/skeletonPort:o");
 
         Property options;
-        options.put("carrier",carrier);
-        options.put("remote",remote);
+        options.put("carrier",carrier.c_str());
+        options.put("remote",remote.c_str());
         options.put("local",(name+"/client").c_str());
         options.put("verbosity",verbosity);
 
@@ -119,10 +120,10 @@ public:
         depthToDisplay.resize(depth_width,depth_height);
         playersImage.resize(depth_width,depth_height);
         skeletonImage.resize(depth_width,depth_height);
-        
+
         depthTmp=cvCreateImage(cvSize(depth_width,depth_height),IPL_DEPTH_32F,1);
         rgbTmp=cvCreateImage(cvSize(img_width,img_height),IPL_DEPTH_8U,3);
-        
+
         if (showImages)
         {
             cvNamedWindow("rgb",CV_WINDOW_AUTOSIZE);
@@ -174,36 +175,36 @@ public:
 
         client.getPlayersImage(players,playersImage);
         client.getDepthImage(depth,depthToDisplay);
-        
+
         if (depthPort.getOutputCount()>0)
         {
             depthPort.prepare()=depthToDisplay;
             depthPort.write();
         }
-        
+
         if (imagePort.getOutputCount()>0)
         {
             imagePort.prepare()=rgb;
             imagePort.write();
         }
-        
+
         if (playersPort.getOutputCount()>0)
         {
             playersPort.prepare()=playersImage;
             playersPort.write();
         }
-        
+
         if (skeletonPort.getOutputCount()>0)
         {
             skeletonPort.prepare()=skeletonImage;
             skeletonPort.write();
         }
-        
+
         int u=160;
         int v=120;
         yarp::sig::Vector point3D;
         client.get3DPoint(u,v,point3D);
-        
+
         fprintf(stdout, "%s\n", point3D.toString().c_str());
 
         if (showImages)

--- a/modules/kinectClientExample/src/main.cpp
+++ b/modules/kinectClientExample/src/main.cpp
@@ -40,7 +40,7 @@ It requires the \ref kinectServer running.
 --remote \e remote
 - specify the kinectServer name to connect to.
 
---local \e name
+--name \e name
 - specify the kinectClient stem-name.
 
 \section tested_os_sec Tested OS
@@ -89,6 +89,8 @@ public:
         int verbosity=rf.check("verbosity",Value(0)).asInt();
         string name=rf.check("name",Value("kinectClientExample")).asString().c_str();
         string show=rf.check("showImages",Value("false")).asString().c_str();
+        string remote=rf.check("remote",Value("kinectServer")).asString().c_str();
+        string carrier=rf.check("carrier",Value("udp")).asString().c_str();
         showImages=(show=="true");
         
         depthPort.open("/"+name+"/depthPort:o");
@@ -97,8 +99,8 @@ public:
         skeletonPort.open("/"+name+"/skeletonPort:o");
 
         Property options;
-        options.put("carrier","udp");
-        options.put("remote","kinectServer");
+        options.put("carrier",carrier);
+        options.put("remote",remote);
         options.put("local",(name+"/client").c_str());
         options.put("verbosity",verbosity);
 


### PR DESCRIPTION
Hi,
this little pull request slightly extends two features of the kinect-wrapper.
1. It allows specifying carrier and remote in the kinectClientExample. So far, these options were existing but not used. Also, the documentation was misleading as changing "local" was documented to change the port name, but "name" is the actual option.
2. For the OpenNI driver, it was not possible so far to change the RGB image size. Therefore, RGB images were always at 320x240 resolution. The little fix introduces the capability to change image width and height.

Both fixes were tested and should work just fine.
@pattacini It would be great if you could merge this :).

Thanks and have a nice week,
Tobias
