### PR TITLE
Allow 640x480 depth images

### DIFF
--- a/library/include/kinectWrapper/kinectDriver.h
+++ b/library/include/kinectWrapper/kinectDriver.h
@@ -1,6 +1,6 @@
 /* Copyright: (C) 2014 iCub Facility - Istituto Italiano di Tecnologia
- * Authors: Ilaria Gori
- * email:   ilaria.gori@iit.it
+ * Authors: Ilaria Gori, Tobias Fischer
+ * email:   ilaria.gori@iit.it, t.fischer@imperial.ac.uk
  * Permission is granted to copy, distribute, and/or modify this program
  * under the terms of the GNU General Public License, version 2 or any
  * later version published by the Free Software Foundation.

--- a/library/include/kinectWrapper/kinectDriver.h
+++ b/library/include/kinectWrapper/kinectDriver.h
@@ -64,11 +64,17 @@ public:
     *    true, otherwise will be false. It can be true only if Microsoft SDK is used.
     *    If it is true, only upper body joints are tracked.
     *
-    * \b image_width <int>: example (image_width 320), specifies the
+    * \b img_width <int>: example (img_width 320), specifies the
     *    width of the rgb image to send.
     *
-    * \b image_height <int>: example (image_height 240), specifies the
+    * \b img_height <int>: example (img_height 240), specifies the
     *    height of the rgb image to send.
+    *
+    * \b depth_width <int>: example (depth_width 320), specifies the
+    *    width of the depth image to send. only for OpenNI driver.
+    *
+    * \b depth_height <int>: example (depth_height 240), specifies the
+    *    height of the depth image to send. only for OpenNI driver.
     *
     * @return true/false if successful/failed.
     */

--- a/library/include/kinectWrapper/kinectDriverOpenNI.h
+++ b/library/include/kinectWrapper/kinectDriverOpenNI.h
@@ -1,6 +1,6 @@
 /* Copyright: (C) 2014 iCub Facility - Istituto Italiano di Tecnologia
- * Authors: Ilaria Gori
- * email:   ilaria.gori@iit.it
+ * Authors: Ilaria Gori, Tobias Fischer
+ * email:   ilaria.gori@iit.it, t.fischer@imperial.ac.uk
  * Permission is granted to copy, distribute, and/or modify this program
  * under the terms of the GNU General Public License, version 2 or any
  * later version published by the Free Software Foundation.

--- a/library/include/kinectWrapper/kinectDriverOpenNI.h
+++ b/library/include/kinectWrapper/kinectDriverOpenNI.h
@@ -43,11 +43,12 @@ private:
     std::string info;
     int img_height;
     int img_width;
-    int def_image_height;
-    int def_image_width;
-    int def_depth_width;
-    int def_depth_height;
-    int device;
+    int img_height_sensor;
+    int img_width_sensor;
+    int depth_width;
+    int depth_height;
+    int depth_width_sensor;
+    int depth_height_sensor;
 
     IplImage* rgb_big;
     IplImage* depthTmp;

--- a/library/include/kinectWrapper/kinectTags.h
+++ b/library/include/kinectWrapper/kinectTags.h
@@ -1,6 +1,6 @@
 /* Copyright: (C) 2014 iCub Facility - Istituto Italiano di Tecnologia
- * Authors: Ilaria Gori
- * email:   ilaria.gori@iit.it
+ * Authors: Ilaria Gori, Tobias Fischer
+ * email:   ilaria.gori@iit.it, t.fischer@imperial.ac.uk
  * Permission is granted to copy, distribute, and/or modify this program
  * under the terms of the GNU General Public License, version 2 or any
  * later version published by the Free Software Foundation.

--- a/library/include/kinectWrapper/kinectTags.h
+++ b/library/include/kinectWrapper/kinectTags.h
@@ -17,13 +17,8 @@
 #ifndef __KINECT_TAGS_H__
 #define __KINECT_TAGS_H__
 
-#define KINECT_TAGS_DEPTH_WIDTH             320
-#define KINECT_TAGS_DEPTH_HEIGHT            240
-
 #define KINECT_TAGS_N_JOINTS                20
 #define KINECT_TAGS_MAX_USERS               15
-#define KINECT_TAGS_DEVICE_KINECT           0
-#define KINECT_TAGS_DEVICE_XTION            1
 
 #define KINECT_TAGS_ALL_INFO                "all_info"
 #define KINECT_TAGS_DEPTH                   "depth"

--- a/library/include/kinectWrapper/kinectWrapper.h
+++ b/library/include/kinectWrapper/kinectWrapper.h
@@ -1,6 +1,6 @@
 /* Copyright: (C) 2014 iCub Facility - Istituto Italiano di Tecnologia
- * Authors: Ilaria Gori
- * email:   ilaria.gori@iit.it
+ * Authors: Ilaria Gori, Tobias Fischer
+ * email:   ilaria.gori@iit.it, t.fischer@imperial.ac.uk
  * Permission is granted to copy, distribute, and/or modify this program
  * under the terms of the GNU General Public License, version 2 or any
  * later version published by the Free Software Foundation.
@@ -15,9 +15,9 @@
  */
 
 /** 
- * \defgroup depthSensing 3D Sensing 
- * Classes for handling 3D sensing. 
- *  
+ * \defgroup depthSensing 3D Sensing
+ * Classes for handling 3D sensing.
+ *
  * \defgroup kinectWrapper kinectWrapper
  * @ingroup depthSensing
  *
@@ -268,5 +268,3 @@ public:
 }
 
 #endif
-
-

--- a/library/include/kinectWrapper/kinectWrapper_client.h
+++ b/library/include/kinectWrapper/kinectWrapper_client.h
@@ -1,6 +1,6 @@
 /* Copyright: (C) 2014 iCub Facility - Istituto Italiano di Tecnologia
- * Authors: Ilaria Gori
- * email:   ilaria.gori@iit.it
+ * Authors: Ilaria Gori, Tobias Fischer
+ * email:   ilaria.gori@iit.it, t.fischer@imperial.ac.uk
  * Permission is granted to copy, distribute, and/or modify this program
  * under the terms of the GNU General Public License, version 2 or any
  * later version published by the Free Software Foundation.

--- a/library/include/kinectWrapper/kinectWrapper_client.h
+++ b/library/include/kinectWrapper/kinectWrapper_client.h
@@ -36,10 +36,10 @@ namespace kinectWrapper
 class KinectWrapperClient : public KinectWrapper
 {
 protected:
-    unsigned short buf[KINECT_TAGS_DEPTH_WIDTH*KINECT_TAGS_DEPTH_HEIGHT];
-    unsigned short bufPl[KINECT_TAGS_DEPTH_WIDTH*KINECT_TAGS_DEPTH_HEIGHT];
-    float bufF[KINECT_TAGS_DEPTH_WIDTH*KINECT_TAGS_DEPTH_HEIGHT];
-    float bufFPl[KINECT_TAGS_DEPTH_WIDTH*KINECT_TAGS_DEPTH_HEIGHT];
+    unsigned short* buf;
+    unsigned short* bufPl;
+    float* bufF;
+    float* bufFPl;
     bool opening;
     bool init;
     bool noRpc;
@@ -48,6 +48,8 @@ protected:
     int verbosity;
     int img_width;
     int img_height;
+    int depth_width;
+    int depth_height;
 
     std::string remote;
     std::string local;

--- a/library/include/kinectWrapper/kinectWrapper_server.h
+++ b/library/include/kinectWrapper/kinectWrapper_server.h
@@ -1,6 +1,6 @@
 /* Copyright: (C) 2014 iCub Facility - Istituto Italiano di Tecnologia
- * Authors: Ilaria Gori
- * email:   ilaria.gori@iit.it
+ * Authors: Ilaria Gori, Tobias Fischer
+ * email:   ilaria.gori@iit.it, t.fischer@imperial.ac.uk
  * Permission is granted to copy, distribute, and/or modify this program
  * under the terms of the GNU General Public License, version 2 or any
  * later version published by the Free Software Foundation.
@@ -26,18 +26,18 @@
 #include <kinectWrapper/kinectWrapper.h>
 
 #ifdef __USE_SDK__
-    #include <kinectWrapper/kinectDriverSDK.h>
+#include <kinectWrapper/kinectDriverSDK.h>
 #endif
 
 #ifdef __USE_OPENNI__
-    #include <kinectWrapper/kinectDriverOpenNI.h>
+#include <kinectWrapper/kinectDriverOpenNI.h>
 #endif
 
 namespace kinectWrapper
 {
 class KinectWrapperServer : public KinectWrapper,
-                  public yarp::os::RateThread,
-                  public yarp::os::PortReader
+        public yarp::os::RateThread,
+        public yarp::os::PortReader
 {
 protected:
     unsigned short* buf;

--- a/library/include/kinectWrapper/kinectWrapper_server.h
+++ b/library/include/kinectWrapper/kinectWrapper_server.h
@@ -51,6 +51,8 @@ protected:
     int verbosity;
     int img_width;
     int img_height;
+    int depth_width;
+    int depth_height;
     yarp::os::Stamp tsD,tsI,tsS;
     double timestampD,timestampI,timestampS;
     std::string name;

--- a/library/src/kinectDriverOpenNI.cpp
+++ b/library/src/kinectDriverOpenNI.cpp
@@ -1,6 +1,6 @@
 /* Copyright: (C) 2014 iCub Facility - Istituto Italiano di Tecnologia
- * Authors: Ilaria Gori
- * email:   ilaria.gori@iit.it
+ * Authors: Ilaria Gori, Tobias Fischer
+ * email:   ilaria.gori@iit.it, t.fischer@imperial.ac.uk
  * Permission is granted to copy, distribute, and/or modify this program
  * under the terms of the GNU General Public License, version 2 or any
  * later version published by the Free Software Foundation.
@@ -227,7 +227,7 @@ bool KinectDriverOpenNI::readDepth(ImageOf<PixelMono16> &depth, double &timestam
             finalValue|=((depth<<3)&0XFFF8);
             finalValue|=(player&0X0007);
             //if (x==320 && y==240)
-             //   fprintf(stdout, "%d %d\n", ((finalValue&0XFFF8)>>3), finalValue&0X0007);
+            //   fprintf(stdout, "%d %d\n", ((finalValue&0XFFF8)>>3), finalValue&0X0007);
             //We associate the depth to the first 13 bits, using the last 3 for the player identification
             depthMat->data.s[y * this->depth_width_sensor + x ]=finalValue;
         }
@@ -312,7 +312,7 @@ bool KinectDriverOpenNI::readSkeleton(Bottle *skeleton, double &timestamp)
                         else
                         {
                             limb.addInt((int)p.X);
-                            limb.addInt((int)p.Y);                           
+                            limb.addInt((int)p.Y);
                         }
                         //OpenNI returns millimiters, we want meters
                         limb.addDouble(joint.position.X/1000);
@@ -349,7 +349,7 @@ bool KinectDriverOpenNI::readSkeleton(Bottle *skeleton, double &timestamp)
             //OPC; if the confidence of all the joints is lower than 0.5, we assume that the tracker actually is not
             //tracking anything, so the only joint written is CoM. In this case we do not send skeleton information.
             if((bones.get(0).asList()->get(1).asList()->get(0).asString()!=KINECT_TAGS_BODYPART_COM));
-                *skeleton=bones;
+            *skeleton=bones;
         }
         return true;
     }
@@ -396,78 +396,78 @@ string KinectDriverOpenNI::jointNameAssociation(XnSkeletonJoint joint)
     string jointName;
     switch (joint)
     {
-        case XN_SKEL_HEAD:
-            jointName=KINECT_TAGS_BODYPART_HEAD;
-            break;
-        case XN_SKEL_LEFT_HAND:
-            jointName=KINECT_TAGS_BODYPART_HAND_L;
-            break;
-        case XN_SKEL_RIGHT_HAND:
-            jointName=KINECT_TAGS_BODYPART_HAND_R;
-            break;
-        case XN_SKEL_LEFT_WRIST:
-            jointName=KINECT_TAGS_BODYPART_WRIST_L;
-            break;
-        case XN_SKEL_RIGHT_WRIST:
-            jointName=KINECT_TAGS_BODYPART_WRIST_R;
-            break;
-        case XN_SKEL_LEFT_ELBOW:
-            jointName=KINECT_TAGS_BODYPART_ELBOW_L;
-            break;
-        case XN_SKEL_RIGHT_ELBOW:
-            jointName=KINECT_TAGS_BODYPART_ELBOW_R;
-            break;
-        case XN_SKEL_NECK:
-            jointName=KINECT_TAGS_BODYPART_SHOULDER_C;
-            break;
-        case XN_SKEL_LEFT_SHOULDER:
-            jointName=KINECT_TAGS_BODYPART_SHOULDER_L;
-            break;
-        case XN_SKEL_RIGHT_SHOULDER:
-            jointName=KINECT_TAGS_BODYPART_SHOULDER_R;
-            break;
-        case XN_SKEL_TORSO:
-            jointName=KINECT_TAGS_BODYPART_SPINE;
-            break;
-        case XN_SKEL_WAIST:
-            jointName=KINECT_TAGS_BODYPART_HIP_C;
-            break;
-        case XN_SKEL_LEFT_HIP:
-            jointName=KINECT_TAGS_BODYPART_HIP_L;
-            break;
-        case XN_SKEL_RIGHT_HIP:
-            jointName=KINECT_TAGS_BODYPART_HIP_R;
-            break;
-        case XN_SKEL_LEFT_KNEE:
-            jointName=KINECT_TAGS_BODYPART_KNEE_L;
-            break;
-        case XN_SKEL_RIGHT_KNEE:
-            jointName=KINECT_TAGS_BODYPART_KNEE_R;
-            break;
-        case XN_SKEL_LEFT_ANKLE :
-            jointName=KINECT_TAGS_BODYPART_ANKLE_L;
-            break;
-        case XN_SKEL_RIGHT_ANKLE :
-            jointName=KINECT_TAGS_BODYPART_ANKLE_R;
-            break;
-        case XN_SKEL_LEFT_FOOT:
-            jointName=KINECT_TAGS_BODYPART_FOOT_L;
-            break;
-        case XN_SKEL_RIGHT_FOOT:
-            jointName=KINECT_TAGS_BODYPART_FOOT_R;
-            break;
-        case XN_SKEL_LEFT_COLLAR:
-            jointName=KINECT_TAGS_BODYPART_COLLAR_L;
-            break;
-        case XN_SKEL_RIGHT_COLLAR:
-            jointName=KINECT_TAGS_BODYPART_COLLAR_R;
-            break;
-        case XN_SKEL_LEFT_FINGERTIP:
-            jointName=KINECT_TAGS_BODYPART_FT_L;
-            break;
-        case XN_SKEL_RIGHT_FINGERTIP:
-            jointName=KINECT_TAGS_BODYPART_FT_R;
-            break;
+    case XN_SKEL_HEAD:
+        jointName=KINECT_TAGS_BODYPART_HEAD;
+        break;
+    case XN_SKEL_LEFT_HAND:
+        jointName=KINECT_TAGS_BODYPART_HAND_L;
+        break;
+    case XN_SKEL_RIGHT_HAND:
+        jointName=KINECT_TAGS_BODYPART_HAND_R;
+        break;
+    case XN_SKEL_LEFT_WRIST:
+        jointName=KINECT_TAGS_BODYPART_WRIST_L;
+        break;
+    case XN_SKEL_RIGHT_WRIST:
+        jointName=KINECT_TAGS_BODYPART_WRIST_R;
+        break;
+    case XN_SKEL_LEFT_ELBOW:
+        jointName=KINECT_TAGS_BODYPART_ELBOW_L;
+        break;
+    case XN_SKEL_RIGHT_ELBOW:
+        jointName=KINECT_TAGS_BODYPART_ELBOW_R;
+        break;
+    case XN_SKEL_NECK:
+        jointName=KINECT_TAGS_BODYPART_SHOULDER_C;
+        break;
+    case XN_SKEL_LEFT_SHOULDER:
+        jointName=KINECT_TAGS_BODYPART_SHOULDER_L;
+        break;
+    case XN_SKEL_RIGHT_SHOULDER:
+        jointName=KINECT_TAGS_BODYPART_SHOULDER_R;
+        break;
+    case XN_SKEL_TORSO:
+        jointName=KINECT_TAGS_BODYPART_SPINE;
+        break;
+    case XN_SKEL_WAIST:
+        jointName=KINECT_TAGS_BODYPART_HIP_C;
+        break;
+    case XN_SKEL_LEFT_HIP:
+        jointName=KINECT_TAGS_BODYPART_HIP_L;
+        break;
+    case XN_SKEL_RIGHT_HIP:
+        jointName=KINECT_TAGS_BODYPART_HIP_R;
+        break;
+    case XN_SKEL_LEFT_KNEE:
+        jointName=KINECT_TAGS_BODYPART_KNEE_L;
+        break;
+    case XN_SKEL_RIGHT_KNEE:
+        jointName=KINECT_TAGS_BODYPART_KNEE_R;
+        break;
+    case XN_SKEL_LEFT_ANKLE :
+        jointName=KINECT_TAGS_BODYPART_ANKLE_L;
+        break;
+    case XN_SKEL_RIGHT_ANKLE :
+        jointName=KINECT_TAGS_BODYPART_ANKLE_R;
+        break;
+    case XN_SKEL_LEFT_FOOT:
+        jointName=KINECT_TAGS_BODYPART_FOOT_L;
+        break;
+    case XN_SKEL_RIGHT_FOOT:
+        jointName=KINECT_TAGS_BODYPART_FOOT_R;
+        break;
+    case XN_SKEL_LEFT_COLLAR:
+        jointName=KINECT_TAGS_BODYPART_COLLAR_L;
+        break;
+    case XN_SKEL_RIGHT_COLLAR:
+        jointName=KINECT_TAGS_BODYPART_COLLAR_R;
+        break;
+    case XN_SKEL_LEFT_FINGERTIP:
+        jointName=KINECT_TAGS_BODYPART_FT_L;
+        break;
+    case XN_SKEL_RIGHT_FINGERTIP:
+        jointName=KINECT_TAGS_BODYPART_FT_R;
+        break;
     }
     return jointName;
 }

--- a/library/src/kinectDriverSDK.cpp
+++ b/library/src/kinectDriverSDK.cpp
@@ -19,6 +19,9 @@
 #include <yarp/os/Network.h>
 #include <kinectWrapper/kinectDriverSDK.h>
 
+#define KINECT_TAGS_DEPTH_WIDTH             320
+#define KINECT_TAGS_DEPTH_HEIGHT            240
+
 using namespace std;
 using namespace yarp::os;
 using namespace yarp::sig;

--- a/library/src/kinectWrapper_client.cpp
+++ b/library/src/kinectWrapper_client.cpp
@@ -1,6 +1,6 @@
 /* Copyright: (C) 2014 iCub Facility - Istituto Italiano di Tecnologia
- * Authors: Ilaria Gori
- * email:   ilaria.gori@iit.it
+ * Authors: Ilaria Gori, Tobias Fischer
+ * email:   ilaria.gori@iit.it, t.fischer@imperial.ac.uk
  * Permission is granted to copy, distribute, and/or modify this program
  * under the terms of the GNU General Public License, version 2 or any
  * later version published by the Free Software Foundation.
@@ -69,7 +69,7 @@ bool KinectWrapperClient::open(const Property &options)
 
     carrier=opt.check("carrier",Value("udp")).asString().c_str();
     verbosity=opt.check("verbosity",Value(0)).asInt();
-	noRpc = opt.check("noRPC");
+    noRpc = opt.check("noRPC");
 
     if (opt.check("remote"))
         remote=opt.find("remote").asString().c_str();
@@ -88,69 +88,69 @@ bool KinectWrapperClient::open(const Property &options)
     }
 
     depthPort.open(("/"+local+"/depth:i").c_str());
-	  bool ok = true;
-	  if (!noRpc)
-	  {
-		    rpc.open(("/" + local + "/rpc").c_str());
-		    ok &= Network::connect(rpc.getName().c_str(), ("/" + remote + "/rpc").c_str());
-	  }
-	  else
-	  {
-		    printf("noRPC option. Working with info/size from client options.\n");
-		    info = opt.check("info", Value(KINECT_TAGS_ALL_INFO)).asString();
-            img_width = opt.check("width", Value(320)).asInt();
-            img_height = opt.check("height", Value(240)).asInt();
-            depth_width = opt.check("depth_width", Value(320)).asInt();
-            depth_height = opt.check("depth_height", Value(240)).asInt();
-	  }
+    bool ok = true;
+    if (!noRpc)
+    {
+        rpc.open(("/" + local + "/rpc").c_str());
+        ok &= Network::connect(rpc.getName().c_str(), ("/" + remote + "/rpc").c_str());
+    }
+    else
+    {
+        printf("noRPC option. Working with info/size from client options.\n");
+        info = opt.check("info", Value(KINECT_TAGS_ALL_INFO)).asString();
+        img_width = opt.check("width", Value(320)).asInt();
+        img_height = opt.check("height", Value(240)).asInt();
+        depth_width = opt.check("depth_width", Value(320)).asInt();
+        depth_height = opt.check("depth_height", Value(240)).asInt();
+    }
 
-	  if (!noRpc)
-	  {
-		    if (ok)
-		    {
-			      Bottle cmd, reply;
-			      cmd.addString(KINECT_TAGS_CMD_PING);
+    if (!noRpc)
+    {
+        if (ok)
+        {
+            Bottle cmd, reply;
+            cmd.addString(KINECT_TAGS_CMD_PING);
 
-			      if (rpc.write(cmd, reply))
-			      {
-				        if (reply.size() > 0)
-				        {
-					          if (reply.get(0).asString() == KINECT_TAGS_CMD_ACK)
-					          {
-						            printMessage(1, "successfully connected with the server %s!\n", remote.c_str());
+            if (rpc.write(cmd, reply))
+            {
+                if (reply.size() > 0)
+                {
+                    if (reply.get(0).asString() == KINECT_TAGS_CMD_ACK)
+                    {
+                        printMessage(1, "successfully connected with the server %s!\n", remote.c_str());
 
-						            info = reply.get(1).asString().c_str();
-						            img_width = reply.get(2).asInt();
-						            img_height = reply.get(3).asInt();
-						            if (reply.get(4).asString() == KINECT_TAGS_SEATED_MODE)
-							            seatedMode = true;
-						            else
-							            seatedMode = false;
-						            if (reply.get(5).asString() == "drawAll")
-							            drawAll = true;
-						            else
-							            drawAll = false;
-                                    depth_width = reply.get(6).asInt();
-                                    depth_height = reply.get(7).asInt();
-					          }
-				        }
-			      }
-			      else
-			      {
-				        printMessage(1, "unable to get correct reply from the server %s!\n", remote.c_str());
-				        close();
+                        info = reply.get(1).asString().c_str();
+                        img_width = reply.get(2).asInt();
+                        img_height = reply.get(3).asInt();
+                        if (reply.get(4).asString() == KINECT_TAGS_SEATED_MODE)
+                            seatedMode = true;
+                        else
+                            seatedMode = false;
+                        if (reply.get(5).asString() == "drawAll")
+                            drawAll = true;
+                        else
+                            drawAll = false;
+                        depth_width = reply.get(6).asInt();
+                        depth_height = reply.get(7).asInt();
+                    }
+                }
+            }
+            else
+            {
+                printMessage(1, "unable to get correct reply from the server %s!\n", remote.c_str());
+                close();
 
-				        return false;
-			      }
-		    }
-		    else
-		    {
-			      printMessage(1, "unable to connect to the server %s!\n", remote.c_str());
-			      close();
+                return false;
+            }
+        }
+        else
+        {
+            printMessage(1, "unable to connect to the server %s!\n", remote.c_str());
+            close();
 
-			      return false;
-		    }
-	  }
+            return false;
+        }
+    }
 
     depthCV=cvCreateImageHeader(cvSize(depth_width,depth_height),IPL_DEPTH_16U,1);
     depthCVPl=cvCreateImageHeader(cvSize(depth_width,depth_height),IPL_DEPTH_16U,1);
@@ -195,8 +195,8 @@ void KinectWrapperClient::close()
             rpc.interrupt();
 
         depthPort.close();
-		    if (!noRpc)
-			      rpc.close();
+        if (!noRpc)
+            rpc.close();
 
         if (info==KINECT_TAGS_ALL_INFO || info==KINECT_TAGS_DEPTH_JOINTS)
         {
@@ -707,7 +707,7 @@ void KinectWrapperClient::getSkeletonImage(const std::deque<Player> &players, ya
             if (iterator->second.u!=0 && iterator->second.v!=0 && iterator->first!=KINECT_TAGS_BODYPART_COM)
                 cvCircle(skeletonImage,cvPoint(iterator->second.u,iterator->second.v),5,CV_RGB(255,0,0),-1);
 
-       drawLimb(jointsMap,KINECT_TAGS_BODYPART_HEAD,KINECT_TAGS_BODYPART_SHOULDER_C);
+        drawLimb(jointsMap,KINECT_TAGS_BODYPART_HEAD,KINECT_TAGS_BODYPART_SHOULDER_C);
 
         if(drawAll)
         {

--- a/library/src/kinectWrapper_client.cpp
+++ b/library/src/kinectWrapper_client.cpp
@@ -210,6 +210,11 @@ void KinectWrapperClient::close()
             imagePort.close();
         }
 
+        delete[] buf;
+        delete[] bufPl;
+        delete[] bufF;
+        delete[] bufFPl;
+
         cvReleaseImageHeader(&depthCV);
         cvReleaseImageHeader(&depthCVPl);
         cvReleaseImageHeader(&depthFCV);

--- a/library/src/kinectWrapper_server.cpp
+++ b/library/src/kinectWrapper_server.cpp
@@ -1,6 +1,6 @@
 /* Copyright: (C) 2014 iCub Facility - Istituto Italiano di Tecnologia
- * Authors: Ilaria Gori
- * email:   ilaria.gori@iit.it
+ * Authors: Ilaria Gori, Tobias Fischer
+ * email:   ilaria.gori@iit.it, t.fischer@imperial.ac.uk
  * Permission is granted to copy, distribute, and/or modify this program
  * under the terms of the GNU General Public License, version 2 or any
  * later version published by the Free Software Foundation.
@@ -86,7 +86,7 @@ bool KinectWrapperServer::read(ConnectionReader &connection)
             }
             else
                 reply.addString(KINECT_TAGS_CMD_NACK);
-            }
+        }
     }
 
     ConnectionWriter *returnToSender=connection.getWriter();
@@ -221,9 +221,9 @@ void KinectWrapperServer::threadRelease()
     cvReleaseImage(&depthTmp);
     cvReleaseImage(&depthToShow);
 
-	if (opening)
+    if (opening)
     {
-    	driver->close();
+        driver->close();
         delete driver;
     }
 
@@ -762,7 +762,7 @@ void KinectWrapperServer::getSkeletonImage(const Player &player, yarp::sig::Imag
         if (iterator->second.u!=0 && iterator->second.v!=0)
             cvCircle(skeletonImage,cvPoint(iterator->second.u,iterator->second.v),5,CV_RGB(255,0,0),-1);
 
-   drawLimb(jointsMap,KINECT_TAGS_BODYPART_HEAD,KINECT_TAGS_BODYPART_SHOULDER_C);
+    drawLimb(jointsMap,KINECT_TAGS_BODYPART_HEAD,KINECT_TAGS_BODYPART_SHOULDER_C);
 
     if(useSDK)
     {

--- a/modules/kinectServer/src/main.cpp
+++ b/modules/kinectServer/src/main.cpp
@@ -43,6 +43,12 @@ from a kinect device.
 --img_height \e img_height
 - height of the rgb image to send.
 
+--depth_width \e depth_width
+- width of the depth image to send.
+
+--depth_height \e depth_height
+- height of the depth image to send.
+
 --seatedMode \e seatedMode
 - if put inside the options, the kinect device will be opened in seated mode (only if the driver is SDK).
 
@@ -82,6 +88,8 @@ public:
         string name=rf.check("name",Value("kinectServer")).asString().c_str();
         int img_width=rf.check("img_width",Value(320)).asInt();
         int img_height=rf.check("img_height",Value(240)).asInt();
+        int depth_width=rf.check("depth_width",Value(320)).asInt();
+        int depth_height=rf.check("depth_height",Value(240)).asInt();
         string device=rf.check("device",Value("kinect")).asString().c_str();
 
         Property options;
@@ -90,6 +98,8 @@ public:
         options.put("name",name.c_str());
         options.put("img_width",img_width);
         options.put("img_height",img_height);
+        options.put("depth_width",depth_width);
+        options.put("depth_height",depth_height);
         options.put("device",device.c_str());
         if (rf.check("remap"))
             options.put("remap","true");

--- a/modules/kinectServer/src/main.cpp
+++ b/modules/kinectServer/src/main.cpp
@@ -1,6 +1,6 @@
 /* Copyright: (C) 2014 iCub Facility - Istituto Italiano di Tecnologia
- * Authors: Ilaria Gori
- * email:   ilaria.gori@iit.it
+ * Authors: Ilaria Gori, Tobias Fischer
+ * email:   ilaria.gori@iit.it, t.fischer@imperial.ac.uk
  * Permission is granted to copy, distribute, and/or modify this program
  * under the terms of the GNU General Public License, version 2 or any
  * later version published by the Free Software Foundation.


### PR DESCRIPTION
This PR allows setting the resolution of depth images for the OpenNI driver. Althought it is slow over the network, it might still be desired to have a full resolution depth image in some cases.
Furthermore, the code is cleaned up a little and easier to understand. Also, there are only very few special cases for the Kinect/Xtion differentiation.

Would be great if someone could merge this :).

Thanks,
Tobias